### PR TITLE
Fix null application fee handling and update logged amount for payment intent succeeded event

### DIFF
--- a/backend/app/Services/Domain/Payment/Stripe/EventHandlers/PaymentIntentSucceededHandler.php
+++ b/backend/app/Services/Domain/Payment/Stripe/EventHandlers/PaymentIntentSucceededHandler.php
@@ -120,7 +120,7 @@ class PaymentIntentSucceededHandler
             attributes: [
                 StripePaymentDomainObjectAbstract::LAST_ERROR => $paymentIntent->last_payment_error?->toArray(),
                 StripePaymentDomainObjectAbstract::AMOUNT_RECEIVED => $paymentIntent->amount_received,
-                StripePaymentDomainObjectAbstract::APPLICATION_FEE => $paymentIntent->application_fee_amount,
+                StripePaymentDomainObjectAbstract::APPLICATION_FEE => $paymentIntent->application_fee_amount ?? 0,
                 StripePaymentDomainObjectAbstract::PAYMENT_METHOD_ID => is_string($paymentIntent->payment_method)
                     ? $paymentIntent->payment_method
                     : $paymentIntent->payment_method?->id,
@@ -214,7 +214,7 @@ class PaymentIntentSucceededHandler
         $this->logger->info('Stripe payment intent succeeded event handled', [
             'payment_intent' => $paymentIntent->id,
             'order_id' => $updatedOrder->getId(),
-            'amount_received' => $paymentIntent->amount_received,
+            'amount_received' => $paymentIntent->amount_captured,
             'currency' => $paymentIntent->currency,
         ]);
 


### PR DESCRIPTION
Handle null values for application fee and ensure the logged amount reflects the captured amount instead of the received amount.